### PR TITLE
Fixed issue #71

### DIFF
--- a/plugins/AlleFriezenPlugin.php
+++ b/plugins/AlleFriezenPlugin.php
@@ -18,7 +18,7 @@ class AlleFriezenPlugin extends FancyResearchLinksModule
 	 */
 	public function pluginLabel(): string
 	{
-		return 'Alle Friezen';
+		return 'AlleFriezen';
 	}
 
 	/**

--- a/plugins/AlleGroningersPlugin.php
+++ b/plugins/AlleGroningersPlugin.php
@@ -18,7 +18,7 @@ class AlleGroningersPlugin extends FancyResearchLinksModule
 	 */
 	public function pluginLabel(): string
 	{
-		return 'Alle Groningers';
+		return 'AlleGroningers';
 	}
 
 	/**


### PR DESCRIPTION
Plugin label "Alle Friezen" changed to "AlleFriezen" to match the official name
Plugin label "Alle Groningers" changed to "AlleGroningers" to match the official name