### PR TITLE
Separating Census of Ireland into three different plugins

### DIFF
--- a/plugins/CensusOfIreland1901Plugin.php
+++ b/plugins/CensusOfIreland1901Plugin.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustCarmen\Webtrees\Module\FancyResearchLinks\Plugin;
+
+use Fisharebest\Webtrees\I18N;
+use JustCarmen\Webtrees\Module\FancyResearchLinks\FancyResearchLinksModule;
+
+class CensusOfIreland1901Plugin extends FancyResearchLinksModule
+{
+    public function pluginLabel(): string
+    {
+        return 'National Archives - Census of Ireland 1901';
+    }
+
+    public function pluginName(): string
+    {
+        return strtolower(basename(__FILE__, 'Plugin.php'));
+    }
+
+    public function researchArea(): string
+    {
+        return 'IRL';
+    }
+
+    public function researchLink($attributes): string
+    {
+        // This uses the search syntax from the 2023 version of National Archive - Census Search
+
+        $name = $attributes['NAME'];
+
+        return 'http://www.census.nationalarchives.ie/search/results.jsp?searchMoreVisible=true&census_year=1901&surname=' . $name['surname'] . '&firstname=' . $name['first'] . '&search=Search';
+    }
+}

--- a/plugins/CensusOfIreland1911Plugin.php
+++ b/plugins/CensusOfIreland1911Plugin.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustCarmen\Webtrees\Module\FancyResearchLinks\Plugin;
+
+use Fisharebest\Webtrees\I18N;
+use JustCarmen\Webtrees\Module\FancyResearchLinks\FancyResearchLinksModule;
+
+class CensusOfIreland1911Plugin extends FancyResearchLinksModule
+{
+    public function pluginLabel(): string
+    {
+        return 'National Archives - Census of Ireland 1911';
+    }
+
+    public function pluginName(): string
+    {
+        return strtolower(basename(__FILE__, 'Plugin.php'));
+    }
+
+    public function researchArea(): string
+    {
+        return 'IRL';
+    }
+
+    public function researchLink($attributes): string
+    {
+        // This uses the search syntax from the 2023 version of National Archive - Census Search
+
+        $name = $attributes['NAME'];
+
+        return 'http://www.census.nationalarchives.ie/search/results.jsp?searchMoreVisible=true&census_year=1911&surname=' . $name['surname'] . '&firstname=' . $name['first'] . '&search=Search';
+    }
+}

--- a/plugins/CensusOfIrelandPlugin.php
+++ b/plugins/CensusOfIrelandPlugin.php
@@ -11,7 +11,7 @@ class CensusOfIrelandPlugin extends FancyResearchLinksModule
 {
     public function pluginLabel(): string
     {
-        return 'National Archives - Census of Ireland';
+        return 'National Archives - Census of Ireland - Advanced Search (link only)';
     }
 
     public function pluginName(): string
@@ -26,10 +26,8 @@ class CensusOfIrelandPlugin extends FancyResearchLinksModule
 
     public function researchLink($attributes): string
     {
-        // This uses the search syntax from the 2023 version of National Archive - Census Search
-
-        $name = $attributes['NAME'];
-
-        return 'http://www.census.nationalarchives.ie/search/results.jsp?searchMoreVisible=true&surname=' . $name['surname'] . '&firstname=' . $name['first'];
+        // This is a link to the search Census page of the 2023 version of National Archive - Census Search
+        
+        return 'http://www.census.nationalarchives.ie/search/#searchmore';
     }
 }


### PR DESCRIPTION
Hi, I separated the Census into 3 different plugin's.  Two that pass through and search the census year (ie 1901 or 1911) by name and one link only for more advanced searching, including census fragments for older incomplete census years.

Does this make sense?