### PR TITLE
Plugins to a few Danish research sites

### DIFF
--- a/plugins/KbhArkivPlugin.php
+++ b/plugins/KbhArkivPlugin.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustCarmen\Webtrees\Module\FancyResearchLinks\Plugin;
+
+/**
+ * Fritekstsøgning på efternavn i Københavns Stadsarkiv.
+ * Mest anvendelig med lidt sjældnere efternavne.
+ */
+
+use Fisharebest\Webtrees\I18N;
+use JustCarmen\Webtrees\Module\FancyResearchLinks\FancyResearchLinksModule;
+
+class KbhArkivPlugin extends FancyResearchLinksModule
+{
+    public function pluginLabel(): string
+    {
+        return 'Københavns Stadsarkiv';
+    }
+
+    public function pluginName(): string
+	{
+		return strtolower(basename(__FILE__, 'Plugin.php'));
+	}
+
+    public function researchArea(): string
+    {
+        return 'DNK';
+    }
+
+    public function researchLink($attributes): string
+    {
+    $name = $attributes['NAME'];
+
+        return 'https://kbharkiv.dk/brug-samlingerne/soeg-i-indtastede-kilder/results?q1.f=freetext_store&q1.op=in_multivalued&q1.t=' . $name['surn'];
+    }
+}

--- a/plugins/LinkLivesPlugin.php
+++ b/plugins/LinkLivesPlugin.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustCarmen\Webtrees\Module\FancyResearchLinks\Plugin;
+
+use JustCarmen\Webtrees\Module\FancyResearchLinks\FancyResearchLinksModule;
+
+class LinkLivesPlugin extends FancyResearchLinksModule
+{
+  	public function pluginLabel(): string
+    {
+		return 'Link-Lives';
+	}
+
+	public function pluginName(): string
+	{
+		return strtolower(basename(__FILE__, 'Plugin.php'));
+	}
+
+	public function researchArea(): string
+    {
+		return 'DNK';
+	}
+
+	public function researchLink($attributes): string
+    {
+      $name = $attributes['NAME'];
+	  $year = $attributes['YEAR'];
+	  $place = $attributes['PLACE'];
+
+		return 'https://link-lives.dk/soeg/results?firstName=' . $name['givn'] . '&lastName=' . $name['surn'] . '&birthYear=' . $year['BIRT'] . '&birthPlace=' . $place['BIRT'] . '&index=pas,lifecourses&sortBy=relevance&sortOrder=desc&mode=default&pg=1&size=50';
+	}
+}

--- a/plugins/OdenseDBPlugin.php
+++ b/plugins/OdenseDBPlugin.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustCarmen\Webtrees\Module\FancyResearchLinks\Plugin;
+
+use JustCarmen\Webtrees\Module\FancyResearchLinks\FancyResearchLinksModule;
+
+class OdenseDBPlugin extends FancyResearchLinksModule
+{
+    public function pluginLabel(): string
+    {
+        return 'Odensedatabasen';
+    }
+
+    public function pluginName(): string
+	{
+		return strtolower(basename(__FILE__, 'Plugin.php'));
+	}
+
+    public function researchArea(): string
+    {
+        return 'DNK';
+    }
+
+    public function researchLink($attributes): string
+    {
+    $name = $attributes['NAME'];
+    
+        return 'https://www.odensedatabasen.dk/kilde/begivenhed?fornavn=' . $name['first'] . '&efternavn=' . $name['surn'];
+    }
+}

--- a/plugins/PolRegisterPlugin.php
+++ b/plugins/PolRegisterPlugin.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustCarmen\Webtrees\Module\FancyResearchLinks\Plugin;
+
+use JustCarmen\Webtrees\Module\FancyResearchLinks\FancyResearchLinksModule;
+
+class PolRegisterPlugin extends FancyResearchLinksModule
+{
+    public function pluginLabel(): string
+    {
+        return 'Politiets Registerblade';
+    }
+
+    public function pluginName(): string
+	{
+		return strtolower(basename(__FILE__, 'Plugin.php'));
+	}
+
+    public function researchArea(): string
+    {
+        return 'DNK';
+    }
+
+    public function researchLink($attributes): string
+    {
+    $name = $attributes['NAME'];
+
+        return 'https://kbharkiv.dk/brug-samlingerne/soeg-i-indtastede-kilder/results?q1.f=lastname&q1.op=in&q1.t=' . $name['surn'] . '&q2.f=firstnames&q2.op=in&q2.t=' . $name['first'] . '&sortField=lastname&sortDirection=asc&postsPrPage=10&collections=17&type=advanced';
+    }
+}


### PR DESCRIPTION
Simple opslag på

- [Odensedatabasen](https://www.odensedatabasen.dk/)
- [LinkLives](https://link-lives.dk/)
- [Københavns Stadsarkiv](https://kbharkiv.dk/) (på tværs af registrene)
- Specifikt _Politiets Registerblade_ i Københavns Stadsarkiv