### PR TITLE
Update AncestryPlugin.php - fix language codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 poeditor-config.json
 compile-mo.bat
 format-pot.bat
+.DS_Store
+.nova/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 poeditor-config.json
 compile-mo.bat
 format-pot.bat
+.DS_Store
+.nova/
+

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,3 @@
 poeditor-config.json
 compile-mo.bat
 format-pot.bat
-.DS_Store
-.nova/

--- a/plugins/AncestryPlugin.php
+++ b/plugins/AncestryPlugin.php
@@ -29,9 +29,9 @@ class AncestryPlugin extends FancyResearchLinksModule
 		$domain = [
 		// these are all the languages supported by ancestry. See: http://corporate.ancestry.com/about-ancestry/international/
 		'de'     => 'de', // German
-		'en_GB'  => 'co.uk',
-		'en_US'  => 'com',
-		'en_AUS' => 'com.au', // not used by webtrees
+		'en-GB'  => 'co.uk',
+		'en-US'  => 'com',
+		'en-AU' => 'com.au', // not used by webtrees
 		'fr'     => 'fr',
 		'it'     => 'it',
 		'sv'     => 'se', // Swedish
@@ -41,7 +41,7 @@ class AncestryPlugin extends FancyResearchLinksModule
 		if (isset($domain[$locale])) {
 			$ancestry_domain = $domain[$locale];
 		} else {
-			$ancestry_domain = $domain['en_US'];
+			$ancestry_domain = $domain['en-US'];
 		}
 
 		$name = $attributes['NAME'];

--- a/plugins/CWGCPlugin.php
+++ b/plugins/CWGCPlugin.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustCarmen\Webtrees\Module\FancyResearchLinks\Plugin;
+
+use Fisharebest\Webtrees\I18N;
+use JustCarmen\Webtrees\Module\FancyResearchLinks\FancyResearchLinksModule;
+
+class CWGCPlugin extends FancyResearchLinksModule
+{
+	public function pluginLabel(): string
+	{
+		return 'Commonwealth War Graves Commission';
+	}
+
+	public function pluginName(): string
+	{
+		return strtolower(basename(__FILE__, 'Plugin.php'));
+	}
+
+	public function researchArea(): string
+	{
+		return 'GBR';
+	}
+
+	public function researchLink($attributes): string
+	{
+		$name = $attributes['NAME'];
+
+		return 'https://www.cwgc.org/search-results/?Term=' . $name['first'] . ' + ' . $name['surname'];
+	}
+}

--- a/plugins/NZbmdBirthsPlugin.php
+++ b/plugins/NZbmdBirthsPlugin.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustCarmen\Webtrees\Module\FancyResearchLinks\Plugin;
+
+use Fisharebest\Webtrees\I18N;
+use JustCarmen\Webtrees\Module\FancyResearchLinks\FancyResearchLinksModule;
+
+class NZbmdBirthsPlugin extends FancyResearchLinksModule
+{
+	public function pluginLabel(): string
+	{
+		return 'New Zealand BMD\'s - Births (' . I18N::translate('link only') . ')';
+	}
+
+	public function pluginName(): string
+	{
+		return strtolower(basename(__FILE__, 'Plugin.php'));
+	}
+
+	public function researchArea(): string
+	{
+		return 'NZL';
+	}
+
+	public function researchLink($attributes): string
+	{
+		return 'https://www.bdmhistoricalrecords.dia.govt.nz/Search/Search?Path=querySubmit.m%3fReportName%3dBirthSearch';
+	}
+}

--- a/plugins/NZbmdDeathsPlugin.php
+++ b/plugins/NZbmdDeathsPlugin.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustCarmen\Webtrees\Module\FancyResearchLinks\Plugin;
+
+use Fisharebest\Webtrees\I18N;
+use JustCarmen\Webtrees\Module\FancyResearchLinks\FancyResearchLinksModule;
+
+class NZbmdDeathsPlugin extends FancyResearchLinksModule
+{
+	public function pluginLabel(): string
+	{
+		return 'New Zealand BMD\'s - Deaths (' . I18N::translate('link only') . ')';
+	}
+
+	public function pluginName(): string
+	{
+		return strtolower(basename(__FILE__, 'Plugin.php'));
+	}
+
+	public function researchArea(): string
+	{
+		return 'NZL';
+	}
+
+	public function researchLink($attributes): string
+	{
+		return 'https://www.bdmhistoricalrecords.dia.govt.nz/Search/Search?Path=querySubmit.m%3fReportName%3dDeathSearch';
+	}
+}

--- a/plugins/NZbmdMarriagesPlugin.php
+++ b/plugins/NZbmdMarriagesPlugin.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustCarmen\Webtrees\Module\FancyResearchLinks\Plugin;
+
+use Fisharebest\Webtrees\I18N;
+use JustCarmen\Webtrees\Module\FancyResearchLinks\FancyResearchLinksModule;
+
+class NZbmdMarriagesPlugin extends FancyResearchLinksModule
+{
+	public function pluginLabel(): string
+	{
+		return 'New Zealand BMD\'s - Marriages (' . I18N::translate('link only') . ')';
+	}
+
+	public function pluginName(): string
+	{
+		return strtolower(basename(__FILE__, 'Plugin.php'));
+	}
+
+	public function researchArea(): string
+	{
+		return 'NZL';
+	}
+
+	public function researchLink($attributes): string
+	{
+		return 'https://www.bdmhistoricalrecords.dia.govt.nz/Search/Search?Path=querySubmit.m%3fReportName%3dMarriageSearch';
+	}
+}

--- a/plugins/UK_GenRegOfficePlugin.php
+++ b/plugins/UK_GenRegOfficePlugin.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JustCarmen\Webtrees\Module\FancyResearchLinks\Plugin;
+
+use Fisharebest\Webtrees\I18N;
+use JustCarmen\Webtrees\Module\FancyResearchLinks\FancyResearchLinksModule;
+
+class UK_GenRegOfficePlugin extends FancyResearchLinksModule
+{
+	public function pluginLabel(): string
+    {
+		return 'General Register Office (' . I18N::translate('link only') . ')';
+	}
+
+	public function pluginName(): string
+	{
+		return strtolower(basename(__FILE__, 'Plugin.php'));
+	}
+
+	public function researchArea(): string
+    {
+		return 'GBR';
+	}
+
+	public function researchLink($attributes): string
+    {
+		return 'https://www.gro.gov.uk/gro/content/certificates/indexes_search.asp';
+	}
+}


### PR DESCRIPTION
webtrees uses dash, not underscore, and AU not AUS in langiage codes. Found this error while working out why Ancestry link always took me to ancestry.com, despite using British and/or Australian English.